### PR TITLE
[2] Create devcontainer for VSCode.

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -20,9 +20,5 @@
 
 	"mounts": [
 		"type=bind,source=/tmp/.X11-unix/,target=/tmp/.X11-unix/"
-	],
-
-	"runArgs": [
-		"--net=host"
 	]
 }

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,28 @@
+{
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+  
+    "customizations": {
+      "vscode": {
+        "extensions": [
+			"bierner.markdown-mermaid",
+			"davidanson.vscode-markdownlint",
+			"ms-vscode.hexeditor",
+			"rust-lang.rust-analyzer",
+			"serayuzgur.crates",
+			"streetsidesoftware.code-spell-checker",
+			"tamasfe.even-better-toml",
+			"vadimcn.vscode-lldb"
+		]
+      }
+    },
+
+	"mounts": [
+		"type=bind,source=/tmp/.X11-unix/,target=/tmp/.X11-unix/"
+	],
+
+	"runArgs": [
+		"--net=host"
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+    "cSpell.words": [
+        // These words are all from VSCode extensions in the devcontainer.json.
+        "bierner",
+        "davidanson",
+        "hexeditor",
+        "serayuzgur",
+        "tamasfe",
+        "vadimcn",
+        // General development-related words.
+        "devcontainer",
+    ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM rust:1.72.0-bookworm AS devcontainer
+
+RUN set -x \
+    && addgroup --gid 1000 user \
+    && adduser --uid 1000 --gid 1000 --disabled-password --gecos "" user
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN set -x \
+    && apt-get update --yes  \
+    && apt-get install --yes --no-install-recommends \
+        libgtk-3-dev   \
+        libxcursor1    \
+        libxrandr2     \
+        libxi6         \
+        libx11-xcb1    \
+    && apt-get autoremove --yes \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+USER 1000:1000
+ENV DISPLAY=:0
+
+RUN set -x \
+    && rustup component add rustfmt \
+    && rustup component add clippy \
+    && cargo install cargo-audit

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ RUN set -x \
 RUN set -x \
     && apt-get update --yes  \
     && apt-get install --yes --no-install-recommends \
+        # In theory, egui should only require libgtk-3-0 (not the dev package),
+        # but using the non-dev package we get no UI and the "NoGlutinConfigs"
+        # error, as described here: https://github.com/emilk/egui/issues/3174
         libgtk-3-dev   \
         libxcursor1    \
         libxrandr2     \


### PR DESCRIPTION
Closes #2.

Adds a Dockerfile and VSCode devcontainer.json configuration file to build, lint, test, and run `kaiseki` from within VSCode. Also adds a VSCode workspace settings file with a number of added word spellings for cSpell.